### PR TITLE
Fix setup.sh not installing all required pip modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyAudio==0.2.11
-numpy==1.16.2
+numpy==1.17.0
 coloredlogs==15.0
 scipy==1.3.0
 Flask==1.1.2

--- a/setup.sh
+++ b/setup.sh
@@ -80,12 +80,8 @@ sudo apt-get -y install python3 python3-pip python3-scipy  # Fallback scipy modu
 
 
 # Install required Python modules:
-sudo pip3 install --no-input --upgrade pip     # Upgrade Pip to the latest version.
-sudo pip3 install --no-input -I numpy==1.17.0  # Offers a lot of mathematical functions and matrix manipulation. This version is required because 1.16 has a memory leak when using queues.
-sudo pip3 install --no-input rpi_ws281x        # Raspberry Pi PWM library for WS281X LEDs.
-sudo pip3 install --no-input flask             # The webserver component.
-sudo pip3 install --no-input pyaudio           # Offer the audio input stream, which will be processed.
-sudo pip3 install --no-input scipy==1.3.0      # Offers a Gaussian filter.
+sudo pip3 install --no-input --upgrade pip        # Upgrade Pip to the latest version.
+sudo pip3 install --no-input -r requirements.txt  # Install modules from requirements.txt.
 
 prompt -s "\nPackages updated and installed."
 


### PR DESCRIPTION
This PR contains the following changes:

* Use `requirements.txt` inside `setup.sh` instead of manually installing each module. (#92)
* Bump `numpy` to `1.17.0` in `requirements.txt`.