### PR TITLE
Use PWM channel from device config

### DIFF
--- a/server/libs/outputs/output_raspi.py
+++ b/server/libs/outputs/output_raspi.py
@@ -62,7 +62,7 @@ class OutputRaspi(Output):
 
         self._leds = ws.new_ws2811_t()
 
-        self.channel = ws.ws2811_channel_get(self._leds, 0)
+        self.channel = ws.ws2811_channel_get(self._leds, self._led_channel)
 
         ws.ws2811_channel_t_strip_type_set(self.channel, self._led_strip_translated)
         ws.ws2811_channel_t_count_set(self.channel, self._led_count)


### PR DESCRIPTION
Enables using the two PWM channels on Raspberry Pi. 
Tested and its working, but the result is unpleasent on a Pi3b (unstable flickering) 😞