### PR TITLE
Bump rpi_ws281x from 4.3.0 to 4.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask==2.0.3
 Flask_Login==0.5.0
 Jinja2==3.0.1
 waitress==2.1.1
-rpi_ws281x==4.3.0
+rpi_ws281x==4.3.4
 icmplib==3.0
 flasgger==0.9.5
 psutil


### PR DESCRIPTION
This adds support for more Raspberry Pi 4 Revisions.
See https://github.com/rpi-ws281x/rpi-ws281x-python/releases for changelog and https://github.com/jgarff/rpi_ws281x/issues/483.