### PR TITLE
fixed conversion error in output_udp leading to crash

### DIFF
--- a/server/libs/outputs/output_udp.py
+++ b/server/libs/outputs/output_udp.py
@@ -20,7 +20,7 @@ class OutputUDP(Output):
 
     def show(self, output_array):
 
-        output_array *= self._led_brightness / 100
+        output_array = (output_array * self._led_brightness / 100)
 
         output_array = self.map_channels(output_array)
         # Typecast the array to int.


### PR DESCRIPTION
Quick fix to get around a conversion error which lead to mlsc crashing when using esp clients.

Original error:
>File "/share/music_led_strip_control/server/libs/outputs/output_udp.py", line 23, in show
>output_array *= self._led_brightness / 100
>numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'